### PR TITLE
(libretro) Don't define FASTCALL if it has been defined already.

### DIFF
--- a/sdl2/libretro/compiler.h
+++ b/sdl2/libretro/compiler.h
@@ -240,7 +240,9 @@ typedef SINT32	FILELEN;
 //#define UINT32_TO_PTR(v)	GUINT_TO_POINTER((UINT32)(v))
 
 //outdated things to ignore
+#if !defined(FASTCALL)
 #define	FASTCALL
+#endif
 #define	CPUCALL
 #define	MEMCALL
 #define	DMACCALL


### PR DESCRIPTION
NOTE: I do not have win32 and have not tested that this fixes the problem, but this seems to have been a problem before and I just copied from other parts of the code base.

Please either test that this works or if preferred let the buildbot test this. I'll send a PR upstream if it all goes well.