### PR TITLE
(libretro) Attempt to further fix windows builds.

### DIFF
--- a/sdl2/dosio.c
+++ b/sdl2/dosio.c
@@ -187,7 +187,7 @@ short file_rename(const char *existpath, const char *newpath) {
 short file_dircreate(const char *path) {
 
 #if !(defined(__LIBRETRO__) && defined(VITA))
-#if defined(WIN32) && (!defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#if defined(_WIN32) && (!defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 	return((short)mkdir(path));
 #else
 	return((short)mkdir(path, 0777));
@@ -199,7 +199,6 @@ short file_dirdelete(const char *path) {
 
 	return((short)rmdir(path));
 }
-
 
 /* カレントファイル操作 */
 void file_setcd(const char *exepath) {


### PR DESCRIPTION
I noticed now that there was another buildbot  build failure for the `cores-windows-x64_seh-generic` recipe.
```
../sdl2/dosio.c: In function 'file_dircreate':

../sdl2/dosio.c:193:16: error: too many arguments to function 'mkdir'

  return((short)mkdir(path, 0777));

                ^~~~~

In file included from ../sdl2/libretro/libretro-common/include/retro_dirent.h:41:0,

                 from ../sdl2/dosio.c:10:

C:/msys64/mingw64/x86_64-w64-mingw32/include/direct.h:59:15: note: declared here

   int __cdecl mkdir(const char *_Path) __MINGW_ATTRIB_DEPRECATED_MSVC2005;

               ^~~~~

make: *** [Makefile.libretro:326: ../sdl2/dosio.o] Error 1
make: *** Waiting for unfinished jobs....
```
My understanding this is because the compiler defines `_WIN32` while the code is checking for `WIN32`. I think its likely safe to just change this one line since the file is already checking for both `_WIN32` and `WIN32` in multiple places.

However again I am relying on someone else or the buildbot to test this before I submit it upstream too.