### PR TITLE
fix crash after np2_main failure

### DIFF
--- a/sdl/libretro/libretro.c
+++ b/sdl/libretro/libretro.c
@@ -293,7 +293,7 @@ int pre_main(const char *argv) {
 
    xargv_cmd[PARAMCOUNT - 2] = NULL;
 
-   return 0;
+   return i;
 }
 
 void parse_cmdline(const char *argv) {
@@ -1696,7 +1696,8 @@ void retro_init (void)
 
 void retro_deinit(void)
 {
-   np2_end();
+   if (!firstcall)
+      np2_end();
 }
 
 void retro_reset (void)
@@ -1717,7 +1718,9 @@ void retro_run (void)
 {
    if(firstcall)
    {
-      pre_main(RPATH);
+      if (pre_main(RPATH) != SUCCESS) {
+         return;
+      }
       update_variables();
       pccore_cfgupdate();
       pccore_reset();


### PR DESCRIPTION
If `np2_main` is never called (due to `retro_init` failing) or if `np2_main` fails (from `pre_main` in `retro_run`) then `np2_end` in `retro_deinit` will crash. This prevents calling `np2_end` unless `np2_main` returns `SUCCESS`.