### PR TITLE
libretro: fix the CI builds broken by the upstream sync

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -12,7 +12,7 @@ CORE_DIR := $(LOCAL_PATH)/..
 
 include $(CORE_DIR)/sdl/Makefile.common
 
-INCFLAGS += (NP21_INCFLAGS) \
+INCFLAGS += $(NP21_INCFLAGS) \
 	-I$(NP2_PATH)/sdl/libretro \
 	-I$(NP2_PATH)/sdl/libretro/libretro-common/include \
 	-I$(NP2_PATH)/sdl/libretro/libretro-common/include/array \

--- a/np2_thread.h
+++ b/np2_thread.h
@@ -122,7 +122,10 @@ extern void NP2_WaitQueue_Shift_Wait(NP2_WaitQueue_t* pque, NP2_Semaphore_t* pse
 #define NP2_Sleep_ms(ms) retro_sleep(ms);
 #endif
 
-#if !defined(NP2_WIN)
+/* np2_tickcount.c only provides these where Windows does not: keep the
+   declaration and the definition behind the same guard, or the Win32
+   prototypes from <windows.h> clash with them (mingw libretro build) */
+#if !defined(_WINDOWS)
 extern BOOL QueryPerformanceCounter(LARGE_INTEGER* count);
 extern BOOL QueryPerformanceFrequency(LARGE_INTEGER* freq);
 #endif

--- a/pccore.c
+++ b/pccore.c
@@ -218,8 +218,6 @@ const OEMCHAR np2version[] = OEMTEXT(NP2KAI_GIT_TAG " " NP2KAI_GIT_HASH);
 				100,
 				OEMTEXT(""),
 				0,
-				0,
-				0,
 #if defined(SUPPORT_DEBUGSS)
 				0,
 #endif

--- a/sdl/Makefile.libretro
+++ b/sdl/Makefile.libretro
@@ -474,6 +474,8 @@ else ifneq (,$(filter $(platform),ngc wii))
 # Nintendo WiiU
 else ifeq ($(platform), wiiu)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
+	# ymfm needs C++14; devkitPPC's g++ still defaults to an older dialect
+	CXX_VER = -std=gnu++14
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
@@ -501,7 +503,7 @@ else ifeq ($(platform), libnx)
 	CFLAGS += $(INCDIRS)
 	CFLAGS += -D__SWITCH__ -DHAVE_LIBNX -march=armv8-a -mtune=cortex-a57 -mtp=soft
 	CFLAGS += -Wno-incompatible-pointer-types
-	CXXFLAGS := $(ASFLAGS) $(CFLAGS) -fno-rtti -std=gnu++11
+	CXXFLAGS := $(ASFLAGS) $(CFLAGS) -fno-rtti -std=gnu++14
 	CFLAGS += -std=gnu11
 	LDFLAGS = $(LD_SHARED_LIBRARY_FLAGS) -ltransistor.lib.nro $(LIBTRANSISTOR_LIB_LDFLAGS) -E
 	STATIC_LINKING=1


### PR DESCRIPTION
Master (238b665) is red on eight jobs — android ×4, wiiu, libnx, webos and windows-i686. They are four independent breakages, all fallout from #71/#72:

`jni/Android.mk` lost the `$` in front of `$(NP21_INCFLAGS)`, so a literal `(NP21_INCFLAGS)` reached the compiler command line and the shell refused it: `/bin/sh: 1: Syntax error: "(" unexpected`. That is all four android jobs.

ymfm needs C++14 (`std::make_unique`, relaxed `constexpr`, `constexpr` members of non-literal classes). libnx pinned `-std=gnu++11` and wiiu left `CXX_VER` empty so devkitPPC's g++ fell back to an older dialect; both now ask for `gnu++14`.

`np2_thread.h` declared `QueryPerformanceCounter()`/`QueryPerformanceFrequency()` whenever `NP2_WIN` was undefined, which on the mingw libretro build clashes with the real Win32 prototypes from `<windows.h>`. The definitions in `np2_tickcount.c` are guarded by `!defined(_WINDOWS)`, so the declaration now uses the same guard — they exist together or not at all.

The `np2cfg` initializer had two stray zeros after `fontface`/`slowmous`, so everything from `vf1_enable` on was shifted by two: `vf1_pcount` got 0 instead of 3 and the profile table got 3 and 0. GCC normally only warns about the resulting `{3, 2}` landing on a scalar (`near initialization for 'np2cfg.vf1_profile[1][0]'`), but the webOS toolchain makes it an error. Dropping the two extra zeros lines the initializer back up with `struct tagNP2Config` and fixes the video filter defaults as a side effect. This one is also present upstream in AZO234/NP2kai.

Verified by building the unix libretro target and by reproducing the webOS diagnostic locally — `pccore.c` now compiles without any brace/excess-element warnings.