### PR TITLE
libretro: let ymfm build on the Wii U toolchain

### DIFF
--- a/sound/mamebsd/ymfm.h
+++ b/sound/mamebsd/ymfm.h
@@ -53,6 +53,16 @@
 #include <stdint.h>
 #undef max
 
+// GCC before 5 implements only the C++11 constexpr rules: a single return
+// statement, and a literal enclosing class.  A few of the functions below do
+// not satisfy those, and devkitPPC (Wii U) still ships such a compiler, so
+// drop constexpr there.  None of them is used in a constant expression.
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ < 5
+ #define YMFM_CONSTEXPR inline
+#else
+ #define YMFM_CONSTEXPR constexpr
+#endif
+
 namespace ymfm
 {
 

--- a/sound/mamebsd/ymfm_adpcm.h
+++ b/sound/mamebsd/ymfm_adpcm.h
@@ -84,7 +84,7 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static constexpr uint32_t channel_offset(uint32_t chnum)
+	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;

--- a/sound/mamebsd/ymfm_opl.h
+++ b/sound/mamebsd/ymfm_opl.h
@@ -359,14 +359,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static constexpr uint32_t channel_offset(uint32_t chnum)
+	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static constexpr uint32_t operator_offset(uint32_t opnum)
+	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;

--- a/sound/mamebsd/ymfm_opm.h
+++ b/sound/mamebsd/ymfm_opm.h
@@ -133,14 +133,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static constexpr uint32_t channel_offset(uint32_t chnum)
+	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static constexpr uint32_t operator_offset(uint32_t opnum)
+	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;

--- a/sound/mamebsd/ymfm_opn.h
+++ b/sound/mamebsd/ymfm_opn.h
@@ -763,7 +763,7 @@ public:
 
 protected:
 	// simulate the DAC discontinuity
-	constexpr int32_t dac_discontinuity(int32_t value) const { return (value < 0) ? (value - 3) : (value + 4); }
+	YMFM_CONSTEXPR int32_t dac_discontinuity(int32_t value) const { return (value < 0) ? (value - 3) : (value + 4); }
 
 	// internal state
 	uint16_t m_address;              // address register

--- a/sound/mamebsd/ymfm_opq.h
+++ b/sound/mamebsd/ymfm_opq.h
@@ -130,14 +130,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static constexpr uint32_t channel_offset(uint32_t chnum)
+	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static constexpr uint32_t operator_offset(uint32_t opnum)
+	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;

--- a/sound/mamebsd/ymfm_opz.h
+++ b/sound/mamebsd/ymfm_opz.h
@@ -156,14 +156,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static constexpr uint32_t channel_offset(uint32_t chnum)
+	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static constexpr uint32_t operator_offset(uint32_t opnum)
+	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;


### PR DESCRIPTION
After #73 the wiiu job is the only red one left ([pipeline 103248](https://git.libretro.com/libretro/NP2kai/-/pipelines/103248)). It does now compile with `-std=gnu++14` as intended, but devkitPPC's g++ predates GCC 5, so it implements only the C++11 constexpr rules: the body must be a single return statement, and the enclosing class must be a literal type. ymfm breaks both — nine `channel_offset()`/`operator_offset()` helpers `assert` before returning, and `ym2612::dac_discontinuity()` lives in a class with a non-trivial destructor:

```
ymfm_opn.h:766: error: enclosing class of constexpr non-static member function
'int32_t ymfm::ym2612::dac_discontinuity(int32_t) const' is not a literal type
note: 'ymfm::ym2612' has a non-trivial destructor
```

A `YMFM_CONSTEXPR` macro in `ymfm.h` drops `constexpr` on such compilers and keeps it everywhere else. None of the ten functions is used in a constant expression — they are called from `ymfm_fm.ipp` and `ymfm_opn.cpp` at run time — so the generated code is identical. `std::make_unique`, the other C++14 feature ymfm uses, is a *library* feature and is present in that toolchain's libstdc++ in C++14 mode.

Verified by compiling every ymfm translation unit with the C++11 constexpr rules enforced (`-std=gnu++11 -pedantic-errors`, with the macro's older-compiler branch forced): all ten diagnostics are gone, only the `make_unique` ones remain, which that job will not hit. The unix libretro target still builds unchanged.

Worth noting the real cause is the age of the Wii U image's toolchain — if it ever gets a newer devkitPPC, this can be reverted. The change is also a candidate for upstream NP2kai and for ymfm itself.