### PR TITLE
libretro: drop constexpr on ym2612::dac_discontinuity instead of the macro

### DIFF
--- a/sound/mamebsd/ymfm.h
+++ b/sound/mamebsd/ymfm.h
@@ -53,16 +53,6 @@
 #include <stdint.h>
 #undef max
 
-// GCC before 5 implements only the C++11 constexpr rules: a single return
-// statement, and a literal enclosing class.  A few of the functions below do
-// not satisfy those, and devkitPPC (Wii U) still ships such a compiler, so
-// drop constexpr there.  None of them is used in a constant expression.
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ < 5
- #define YMFM_CONSTEXPR inline
-#else
- #define YMFM_CONSTEXPR constexpr
-#endif
-
 namespace ymfm
 {
 

--- a/sound/mamebsd/ymfm_adpcm.h
+++ b/sound/mamebsd/ymfm_adpcm.h
@@ -84,7 +84,7 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
+	static constexpr uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;

--- a/sound/mamebsd/ymfm_opl.h
+++ b/sound/mamebsd/ymfm_opl.h
@@ -359,14 +359,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
+	static constexpr uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
+	static constexpr uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;

--- a/sound/mamebsd/ymfm_opm.h
+++ b/sound/mamebsd/ymfm_opm.h
@@ -133,14 +133,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
+	static constexpr uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
+	static constexpr uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;

--- a/sound/mamebsd/ymfm_opn.h
+++ b/sound/mamebsd/ymfm_opn.h
@@ -763,7 +763,10 @@ public:
 
 protected:
 	// simulate the DAC discontinuity
-	YMFM_CONSTEXPR int32_t dac_discontinuity(int32_t value) const { return (value < 0) ? (value - 3) : (value + 4); }
+	// (not constexpr: ym2612 is not a literal type, and DR1684 - which allows
+	// a constexpr member function in such a class - is not implemented by
+	// devkitPPC's g++.  Only ever called at run time.)
+	int32_t dac_discontinuity(int32_t value) const { return (value < 0) ? (value - 3) : (value + 4); }
 
 	// internal state
 	uint16_t m_address;              // address register

--- a/sound/mamebsd/ymfm_opq.h
+++ b/sound/mamebsd/ymfm_opq.h
@@ -130,14 +130,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
+	static constexpr uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
+	static constexpr uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;

--- a/sound/mamebsd/ymfm_opz.h
+++ b/sound/mamebsd/ymfm_opz.h
@@ -156,14 +156,14 @@ public:
 	void save_restore(ymfm_saved_state &state);
 
 	// map channel number to register offset
-	static YMFM_CONSTEXPR uint32_t channel_offset(uint32_t chnum)
+	static constexpr uint32_t channel_offset(uint32_t chnum)
 	{
 		assert(chnum < CHANNELS);
 		return chnum;
 	}
 
 	// map operator number to register offset
-	static YMFM_CONSTEXPR uint32_t operator_offset(uint32_t opnum)
+	static constexpr uint32_t operator_offset(uint32_t opnum)
 	{
 		assert(opnum < OPERATORS);
 		return opnum;


### PR DESCRIPTION
My #74 guessed wrong about *why* the wiiu job fails, and [pipeline 103251](https://git.libretro.com/libretro/NP2kai/-/pipelines/103251) says so plainly: the error is still there, but it moved from column 20 to column 25 — exactly the width of `YMFM_CONSTEXPR` expanding back to `constexpr`. The compiler test I added never fires, and every other ymfm translation unit compiled in that same run (`ymfm_adpcm.o`, `ymfm_opl.o`, `ymfm_opm.o`, `ymfm_opq.o`, `ymfm_opz.o`, …). So devkitPPC's g++ is GCC 5 or newer, handles relaxed constexpr bodies fine, and the macro was doing nothing. Sorry for the noise.

What that compiler does *not* implement is [DR1684](https://cplusplus.github.io/CWG/issues/1684.html), which allows a `constexpr` member function in a class that is not a literal type. `ym2612` has a non-trivial destructor, so this one stays rejected:

```
ymfm_opn.h:766: error: enclosing class of constexpr non-static member function
'int32_t ymfm::ym2612::dac_discontinuity(int32_t) const' is not a literal type
note: 'ymfm::ym2612' has a non-trivial destructor
```

It is the only remaining diagnostic and needs no macro: the function is called from `ymfm_opn.cpp` at run time only, so it simply loses `constexpr`. The `YMFM_CONSTEXPR` macro and its nine other uses are reverted, which leaves the vendored ymfm differing from upstream in one function in one file instead of six headers.

Checked locally: the unix libretro target still builds, and compiling `ymfm_opn.cpp` with the pre-DR1684 rules enforced (`-std=gnu++11 -pedantic-errors`) no longer reports the "enclosing class" error — only the relaxed-body one, which that toolchain has just proven it accepts.